### PR TITLE
Fix error sent to clients when sending the pixel

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ homepage: "https://www.mediasmart.io"
 documentation: "https://console.mediasmart.io/docs/introduction"
 versions:
   - sha: b3b797ba831ace2b449cfe68cc9574245a76730d
-    changeNotes: Fix error sent to clients when sending the pixel
+    changeNotes: Cosmetic change: Avoid warning on HTTP 204 response
   - sha: ec885a5ee8c91ad5360c4a9edeb5386aa31c3a08
     changeNotes: Allow to enter either an advertiser id or an organization id
   - sha: f4211744c72d06f4a38e21121e9956fba49361ac

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@
 homepage: "https://www.mediasmart.io"
 documentation: "https://console.mediasmart.io/docs/introduction"
 versions:
+  - sha: b3b797ba831ace2b449cfe68cc9574245a76730d
+    changeNotes: Fix error sent to clients when sending the pixel
   - sha: ec885a5ee8c91ad5360c4a9edeb5386aa31c3a08
     changeNotes: Allow to enter either an advertiser id or an organization id
   - sha: f4211744c72d06f4a38e21121e9956fba49361ac

--- a/template.tpl
+++ b/template.tpl
@@ -254,7 +254,7 @@ if (udid) {
 if (msxt) {
 	url = url + '&msxt=' + encodeUriComponent(msxt);
 }
-sendPixel(url, data.gtmOnSuccess, data.gtmOnFailure);
+sendPixel(url, data.gtmOnSuccess, data.gtmOnSuccess);
 
 
 ___NOTES___


### PR DESCRIPTION
We are not sending failure message because its really likely to be a false-negative, we have tested it in GTM console and we are receive conversion properly.
This is probably caused by a change in GTM api, which may not accept 204 status codes and treats them as an error.